### PR TITLE
add installation method from conda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .vscode
 **/__pycache__
-**/*.pytest_cache
+**/*_cache
 
 .coverage*
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Installation
 pip install flory
 ```
 
+As an alternative, you can install `flory` through [conda](https://docs.conda.io/en/latest/) using the [conda-forge](https://conda-forge.org/) channel:
+
+```bash
+conda install -c conda-forge flory
+```
+
 Usage
 -----
 The following example determines the coexisting phases of a binary mixture with Flory-Huggins free energy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ version_file = "flory/_version.py"
 
 [project.urls]
 homepage = "https://github.com/qiangyicheng/flory"
+documentation = "https://flory.readthedocs.io"
 repository = "https://github.com/qiangyicheng/flory"
 
 [tool.setuptools]


### PR DESCRIPTION
After the package is available from conda-forge, we can merge this to add the installation guide to README.md