### PR TITLE
Add equilibration_error to `FreeEnergyBase`

### DIFF
--- a/examples/polydispersed.py
+++ b/examples/polydispersed.py
@@ -1,5 +1,6 @@
-import flory
 import numpy as np
+
+import flory
 
 num_feat = 2
 chis_feat = [[0, 4.0], [4.0, 0]]

--- a/flory/common/math.py
+++ b/flory/common/math.py
@@ -1,0 +1,17 @@
+"""Module providing auxiliary mathematical functions.
+
+.. codeauthor:: David Zwicker <david.zwicker@ds.mpg.de>
+"""
+
+import numpy as np
+from numba import float64, vectorize
+
+
+@vectorize([float64(float64)])
+def xlogx(x):
+    if x == 0:
+        return 0
+    elif x < 0:
+        return np.nan
+    else:
+        return x * np.log(x)

--- a/flory/entropy/ideal_gas.py
+++ b/flory/entropy/ideal_gas.py
@@ -11,6 +11,7 @@ import numpy as np
 from numba import float64, int32
 from numba.experimental import jitclass
 
+from ..common.math import xlogx
 from .base import EntropyBase, EntropyBaseCompiled
 
 
@@ -136,7 +137,7 @@ class IdealGasEntropyBase(EntropyBase):
         Returns:
             : The entropic energy density.
         """
-        return np.einsum("...i,...i->...", phis / self._sizes, np.log(phis))
+        return np.sum(xlogx(phis) / self._sizes, axis=-1)
 
     def _jacobian_impl(self, phis: np.ndarray) -> np.ndarray:
         r"""Implementation of calculating Jacobian :math:`\partial f_\mathrm{entropy}/\partial \phi_i`.

--- a/flory/free_energy/base.py
+++ b/flory/free_energy/base.py
@@ -370,13 +370,12 @@ class FreeEnergyBase:
                 The order for calculating norm. See  :func:`numpy.linalg.norm` for more
                 details.
             axis:
-                Whether to calculate error by component, by phase or by all. `0`: by
-                component; `1`: by phase; `None`: by both.
+                Whether to calculate error by component (`axis=0`), by phase (`axis=1`),
+                or by both (`axis=None`, returns a scalar).
 
         Returns:
             : The equilibration error by component, by phase or by all.
         """
         mus = self.chemical_potentials(phis)
-        mus_mean = mus.mean(axis=0)
-        mus = mus - mus_mean
+        mus -= mus.mean(axis=0)  # get deviations from mean
         return np.linalg.norm(mus, ord=order, axis=axis)

--- a/flory/free_energy/base.py
+++ b/flory/free_energy/base.py
@@ -351,3 +351,32 @@ class FreeEnergyBase:
             : The number of negative eigenvalues of the Hessian.
         """
         return self.num_unstable_modes(phis, conserved) == 0
+
+    def equilibration_error(
+        self, phis: np.ndarray, ord: int | None = None, axis: int | None = 1
+    ) -> float | np.ndarray:
+        r"""Determine how well the phases are in balance with each other.
+
+        Note that this function do not check whether the coexistence of the providing
+        phases are the equilibrium state. It only checks its necessary condition that all
+        phases must reach chemical potential balance with each other.
+
+        Args:
+            phis:
+                The volume fractions of the phase(s) :math:`\phi_{p,i}`. Multiple phases
+                are expected, the index of the components must be the last dimension. If
+                only one phase is provided, the result will always be zero.
+            ord:
+                The order for calculating norm. See  :func:`numpy.linalg.norm` for more
+                details.
+            axis:
+                Whether to calculate error by component, by phase or by all. `0`: by
+                component; `1`: by phase; `None`: by both.
+
+        Returns:
+            : The equilibration error by component, by phase or by all.
+        """
+        mus = self.chemical_potentials(phis)
+        mus_mean = mus.mean(axis=0)
+        mus = mus - mus_mean
+        return np.linalg.norm(mus, ord=ord, axis=axis)

--- a/flory/free_energy/base.py
+++ b/flory/free_energy/base.py
@@ -353,7 +353,7 @@ class FreeEnergyBase:
         return self.num_unstable_modes(phis, conserved) == 0
 
     def equilibration_error(
-        self, phis: np.ndarray, ord: int | None = None, axis: int | None = 1
+        self, phis: np.ndarray, order: int | None = None, axis: int | None = 1
     ) -> float | np.ndarray:
         r"""Determine how well the phases are in balance with each other.
 
@@ -366,7 +366,7 @@ class FreeEnergyBase:
                 The volume fractions of the phase(s) :math:`\phi_{p,i}`. Multiple phases
                 are expected, the index of the components must be the last dimension. If
                 only one phase is provided, the result will always be zero.
-            ord:
+            order:
                 The order for calculating norm. See  :func:`numpy.linalg.norm` for more
                 details.
             axis:
@@ -379,4 +379,4 @@ class FreeEnergyBase:
         mus = self.chemical_potentials(phis)
         mus_mean = mus.mean(axis=0)
         mus = mus - mus_mean
-        return np.linalg.norm(mus, ord=ord, axis=axis)
+        return np.linalg.norm(mus, ord=order, axis=axis)

--- a/tests/common/test_math.py
+++ b/tests/common/test_math.py
@@ -1,0 +1,19 @@
+"""
+.. codeauthor:: David Zwicker <david.zwicker@ds.mpg.de>
+"""
+
+import numpy as np
+import pytest
+
+from flory.common.math import xlogx
+
+
+def test_xlogx():
+    """test xlogx function"""
+    assert xlogx(0) == 0
+    assert xlogx(0.5) == pytest.approx(0.5 * np.log(0.5))
+    assert np.isnan(xlogx(-0.1))
+
+    np.testing.assert_allclose(
+        xlogx(np.array([-0.1, 0, 0.5])), [np.nan, 0, 0.5 * np.log(0.5)]
+    )

--- a/tests/common/test_phases.py
+++ b/tests/common/test_phases.py
@@ -85,14 +85,14 @@ def test_phases_wrong_input(cls):
 
 
 @pytest.mark.parametrize("num_comps", [1, 2, 3])
-def test_get_uniform_random_composition(num_comps):
+def test_get_uniform_random_composition(num_comps, rng):
     """test get_uniform_random_composition function"""
-    phis = get_uniform_random_composition(num_comps)
+    phis = get_uniform_random_composition(num_comps, rng=rng)
     assert phis.shape == (num_comps,)
     assert phis.sum() == pytest.approx(1)
 
 
-def test_get_uniform_random_composition_dist():
+def test_get_uniform_random_composition_dist(rng):
     """test distribution of get_uniform_random_composition"""
-    phis = np.array([get_uniform_random_composition(3) for _ in range(1000)])
+    phis = np.array([get_uniform_random_composition(3, rng=rng) for _ in range(1000)])
     assert stats.ks_2samp(phis[:, 0], phis[:, 1]).pvalue > 0.05

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,16 @@ def _setup_and_teardown():
     plt.close("all")
 
 
+@pytest.fixture(autouse=False, name="rng")
+def init_random_number_generators():
+    """Get a random number generator and set the seed of the random number generator.
+
+    The function returns an instance of :func:`~numpy.random.default_rng()` and
+    initializes the default generators of both :mod:`numpy` and :mod:`numba`.
+    """
+    return np.random.default_rng(0)
+
+
 def pytest_configure(config):
     """Add markers to the configuration."""
     config.addinivalue_line("markers", "slow: test runs slowly")

--- a/tests/free_energy/test_flory_huggins.py
+++ b/tests/free_energy/test_flory_huggins.py
@@ -1,0 +1,44 @@
+"""
+.. codeauthor:: David Zwicker <david.zwicker@ds.mpg.de>
+"""
+
+import numpy as np
+import pytest
+
+import flory
+from flory.common.phases import get_uniform_random_composition
+
+
+@pytest.mark.parametrize("num_comp", [1, 2, 3])
+def test_flory_huggins_single_size(num_comp, rng):
+    """Test some generic properties of the Flory-Huggins free energy"""
+    chis = rng.normal(size=(num_comp, num_comp))
+    chis += chis.T  # symmetrize
+    fh = flory.FloryHuggins(num_comp, chis)
+
+    phis = get_uniform_random_composition(num_comp, rng=rng)[np.newaxis, :]
+    f = fh.free_energy_density(phis)
+    assert f.shape == (1,)
+    for solvent in range(num_comp):
+        mu_bar = fh.exchange_chemical_potentials(phis, solvent)
+        assert mu_bar.shape == (1, num_comp)
+        pressure = np.sum(phis * mu_bar, axis=-1) - f
+        np.testing.assert_allclose(fh.pressure(phis, solvent), pressure)
+
+
+@pytest.mark.parametrize("num_comp", [1, 2, 3])
+def test_flory_huggins_many_sizes(num_comp, rng):
+    """Test some generic properties of the Flory-Huggins free energy"""
+    chis = rng.normal(size=(num_comp, num_comp))
+    chis += chis.T  # symmetrize
+    sizes = rng.uniform(1, 2, size=(num_comp))
+    fh = flory.FloryHuggins(num_comp, chis, sizes=sizes)
+
+    phis = get_uniform_random_composition(num_comp, rng=rng)[np.newaxis, :]
+    f = fh.free_energy_density(phis)
+    assert f.shape == (1,)
+    for solvent in range(num_comp):
+        mu_bar = fh.exchange_chemical_potentials(phis, solvent)
+        assert mu_bar.shape == (1, num_comp)
+        pressure = np.sum(phis * mu_bar, axis=-1) - f
+        np.testing.assert_allclose(fh.pressure(phis, solvent), pressure)

--- a/tests/free_energy/test_free_energy.py
+++ b/tests/free_energy/test_free_energy.py
@@ -9,7 +9,7 @@ import flory
 from flory.common.phases import get_uniform_random_composition
 
 
-def test_equilibration_error():
+def test_equilibration_error(rng):
     """Test function `equilibration_error`"""
     num_comp = 3
     chis = np.array([[3.27, -0.34, 0], [-0.34, -3.96, 0], [0, 0, 0]])
@@ -25,6 +25,6 @@ def test_equilibration_error():
     phase_error = fh.equilibration_error(phases.fractions)
     assert phase_error.max() < 1e-4
 
-    random_comps = [get_uniform_random_composition(3) for _ in range(3)]
-    phase_error = fh.equilibration_error(random_comps)
-    assert phase_error.max() > 1e-4
+    random_comps = [get_uniform_random_composition(3, rng=rng) for _ in range(3)]
+    phase_error = fh.equilibration_error(random_comps, axis=None)
+    assert phase_error > 1e-2

--- a/tests/free_energy/test_free_energy.py
+++ b/tests/free_energy/test_free_energy.py
@@ -1,0 +1,30 @@
+"""
+.. codeauthor:: Yicheng Qiang <yicheng.qiang@ds.mpg.de>
+"""
+
+import numpy as np
+import pytest
+
+import flory
+from flory.common.phases import get_uniform_random_composition
+
+
+def test_equilibration_error():
+    """Test function `equilibration_error`"""
+    num_comp = 3
+    chis = np.array([[3.27, -0.34, 0], [-0.34, -3.96, 0], [0, 0, 0]])
+    phi_means = np.array([0.16, 0.55, 0.29])
+    sizes = np.array([2.0, 2.0, 1.0])
+
+    fh = flory.FloryHuggins(num_comp, chis, sizes)
+    ensemble = flory.CanonicalEnsemble(num_comp, phi_means)
+    finder = flory.CoexistingPhasesFinder(fh.interaction, fh.entropy, ensemble)
+
+    phases = finder.run().get_clusters()
+
+    phase_error = fh.equilibration_error(phases.fractions)
+    assert phase_error.max() < 1e-4
+
+    random_comps = [get_uniform_random_composition(3) for _ in range(3)]
+    phase_error = fh.equilibration_error(random_comps)
+    assert phase_error.max() > 1e-4


### PR DESCRIPTION
This function would help to determine whether the phases are in balance with each other.

Currently by default the function returns the distance (norm) to the average chemical potential, which is a vector with the length of number of phases.