### PR TITLE
Improve the installation of optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,10 @@ By default, only the minimal set of dependencies of `flory` package will be inst
 pip install 'flory[dev]'
 ```
 
-You can also install only the dependencies for tests:
+You can also select the optional dependencies, such as `example`, `test` or `doc`. For example, you can install the package with the optional dependencies only for tests:
 
 ```bash
 pip install 'flory[test]'
-```
-
-or install only the dependencies for documentations:
-
-```bash
-pip install 'flory[doc]'
 ```
 
 If you are using conda, consider install the optional dependencies directly:
@@ -66,13 +60,7 @@ conda install -c conda-forge --file https://raw.githubusercontent.com/qiangyiche
 
 ### Test installation
 
-If the optional dependencies for tests are installed, you can run tests in root directory of the package:
-
-```bash
-pytest
-```
-
-By default, some slow tests are skipped. You can run them as well with the `--runslow` option:
+If the optional dependencies for tests are installed, you can run tests in root directory of the package with `pytest`. By default, some slow tests are skipped. You can run them with the `--runslow` option:
 
 ```bash
 pytest --runslow

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ $$f(\{\phi_i\}) = \frac{1}{2}\sum_{i,j=1}^{N_\mathrm{C}} \chi_{ij} \phi_i \phi_j
 where $\chi_{ij}$ is the Flory-Huggins interaction parameter between component $i$ and $j$, and $l_i$ is the relative molecular size of component $i$.
 Given an interaction matrix $\chi_{ij}$, average volume fractions of all components across the system $\bar{\phi}_i$, and the relative molecule sizes $l_i$, `flory` provides tools to find the coexisting phases in equilibrium.
 
-Installation
-------------
+## Installation
+
 `flory` is available on `pypi`, so you should be able to install it through `pip`:
 
 ```bash
@@ -37,8 +37,49 @@ As an alternative, you can install `flory` through [conda](https://docs.conda.io
 conda install -c conda-forge flory
 ```
 
-Usage
------
+### Optional dependencies
+
+By default, only the minimal set of dependencies of `flory` package will be installed. To install all dependencies, run:
+
+```bash
+pip install 'flory[dev]'
+```
+
+You can also install only the dependencies for tests:
+
+```bash
+pip install 'flory[test]'
+```
+
+or install only the dependencies for documentations:
+
+```bash
+pip install 'flory[doc]'
+```
+
+If you are using conda, consider install the optional dependencies directly:
+
+```bash
+conda install -c conda-forge --file https://raw.githubusercontent.com/qiangyicheng/flory/main/tests/requirements.txt
+conda install -c conda-forge --file https://raw.githubusercontent.com/qiangyicheng/flory/main/docs/requirements.txt
+```
+
+### Test installation
+
+If the optional dependencies for tests are installed, you can run tests in root directory of the package:
+
+```bash
+pytest
+```
+
+By default, some slow tests are skipped. You can run them as well with the `--runslow` option:
+
+```bash
+pytest --runslow
+```
+
+## Usage
+
 The following example determines the coexisting phases of a binary mixture with Flory-Huggins free energy:
 
 ```python
@@ -72,12 +113,13 @@ phases = finder.run().get_clusters()
 ```
 
 The free energy instance provides more tools for analysis, such as:
+
 ```python
 # calculate the chemical potentials of the coexisting phases
 mus = fh.chemical_potentials(phases.fractions)
 ```
 
-More information
-----------------
+## More information
+
 * See examples in [examples folder](https://github.com/qiangyicheng/flory/tree/main/examples)
 * [Full documentation on readthedocs](https://flory.readthedocs.io/)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ pip install 'flory[test]'
 If you are using conda, consider install the optional dependencies directly:
 
 ```bash
+conda install -c conda-forge --file https://raw.githubusercontent.com/qiangyicheng/flory/main/examples/requirements.txt
 conda install -c conda-forge --file https://raw.githubusercontent.com/qiangyicheng/flory/main/tests/requirements.txt
 conda install -c conda-forge --file https://raw.githubusercontent.com/qiangyicheng/flory/main/docs/requirements.txt
 ```

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,1 @@
+matplotlib>=3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = { file = ["requirements.txt"] }
 optional-dependencies = { dev = { file = [
     "tests/requirements.txt",
     "docs/requirements.txt",
+] }, example = { file = [
+    "examples/requirements.txt",
 ] }, test = { file = [
     "tests/requirements.txt",
 ] }, doc = { file = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ dependencies = { file = ["requirements.txt"] }
 optional-dependencies = { dev = { file = [
     "tests/requirements.txt",
     "docs/requirements.txt",
+] }, test = { file = [
+    "tests/requirements.txt",
+] }, doc = { file = [
+    "docs/requirements.txt",
 ] } }
 
 [tool.setuptools_scm]
@@ -67,27 +71,46 @@ docstring-code-format = true
 [tool.ruff.lint]
 select = [
     "UP",  # pyupgrade
-    "I",  # isort
-    "A",  # flake8-builtins 
-    "B",  # flake8-bugbear
+    "I",   # isort
+    "A",   # flake8-builtins 
+    "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
-    "FA", # flake8-future-annotations
+    "FA",  # flake8-future-annotations
     "ISC", # flake8-implicit-str-concat
     "ICN", # flake8-import-conventions
     "LOG", # flake8-logging
-    "G", # flake8-logging-format
+    "G",   # flake8-logging-format
     "PIE", # flake8-pie
-    "PT", # flake8-pytest-style
-    "Q", # flake8-quotes
+    "PT",  # flake8-pytest-style
+    "Q",   # flake8-quotes
     "RSE", # flake8-raise
     "RET", # flake8-return
     "SIM", # flake8-simplify
     "PTH", # flake8-use-pathlib
 ]
-ignore = ["B007", "B027", "B028", "SIM108", "ISC001", "PT006", "PT011", "PTH123", "RET504", "RET505", "RET506"]
+ignore = [
+    "B007",
+    "B027",
+    "B028",
+    "SIM108",
+    "ISC001",
+    "PT006",
+    "PT011",
+    "PTH123",
+    "RET504",
+    "RET505",
+    "RET506",
+]
 
 [tool.ruff.lint.isort]
-section-order = ["future", "standard-library", "third-party", "first-party", "self", "local-folder"]
+section-order = [
+    "future",
+    "standard-library",
+    "third-party",
+    "first-party",
+    "self",
+    "local-folder",
+]
 
 [tool.ruff.lint.isort.sections]
 self = ["flory"]


### PR DESCRIPTION
Now we provide `example`, `test` and `doc` optional dependencies, and `dev` for both. Since so far Conda does not provide straightforward ways for optional dependencies, we provide commands in [README.md](https://github.com/qiangyicheng/flory/blob/main/README.md) for direct installation.