### PR TITLE
Limited maximal python version and added checks for python 3.13

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Python package for finding coexisting phases in multicomponent mi
 authors = [{ name = "Yicheng Qiang", email = "yicheng.qiang@ds.mpg.de" }]
 license = { text = "MIT License" }
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.14"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
 keywords = ["physics", "phase-separation", "free-energy"]
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
I think it's a good idea to limit the maximally allowed python version, so we are forced to check every new version manually.